### PR TITLE
Ignore environment variables with no value

### DIFF
--- a/papa/__init__.py
+++ b/papa/__init__.py
@@ -416,7 +416,8 @@ class Papa(object):
                     raise utils.Error('stderr must be DEVNULL, PIPE or STDOUT')
         if env:
             for key, value in env.items():
-                command.append('env.{0}={1}'.format(key, wrap_trailing_slash(value)))
+                if (len(str(value)) > 0):
+                    command.append('env.{0}={1}'.format(key, wrap_trailing_slash(value)))
         if rlimits:
             for key, value in rlimits.items():
                 command.append('rlimit.{0}={1}'.format(key.lower(), value))


### PR DESCRIPTION
After patching my local install with #4 , I am still seeing traceback issues when an environment variable is empty.  This patch ignores empty environment variables